### PR TITLE
chore(renovate): pin GitHub Action digests to semver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver",
     ":prHourlyLimitNone"
   ],
   "labels": ["dependencies"],


### PR DESCRIPTION
Extends `helpers:pinGitHubActionDigestsToSemver` so GitHub Actions are pinned to immutable commit digests while keeping a human-readable semver tag comment (Renovate then bumps by semver and refreshes the digest).

This brings the config in line with the other repos (home, shvil, cert-manager-webhook-freemyip, atgardner.github.com) which already extend this helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)